### PR TITLE
Specify image platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/shiny-verse:4.2.2
+FROM --platform=linux/amd64 rocker/shiny-verse:4.2.2
 
 # Install necessary R packages and prepare Shiny server dir.
 RUN apt-get update -qq \


### PR DESCRIPTION
I found that I could not build the Dockerfile without specifying the platform of the image. Since there is only one (`linux/amd64`), I believe this is a canonical solution that should be integrated.